### PR TITLE
Fix Windows compatibility issues

### DIFF
--- a/networks/dymeshvae.py
+++ b/networks/dymeshvae.py
@@ -210,7 +210,7 @@ class SyncAttention(nn.Module):
         v2 = self.to_v2(v2_stream)
         q, k, v1, v2 = map(lambda t: rearrange(t, 'b n (h d) -> b h n d', h=h), (q, k, v1, v2))
         v_cat = torch.cat([v1, v2], dim=-1)
-        with torch.backends.cuda.sdp_kernel(enable_math=False):
+        with torch.backends.cuda.sdp_kernel(enable_math=True):
             out_cat = F.scaled_dot_product_attention(q, k, v_cat)
         out1, out2 = out_cat.chunk(2, dim=-1)
         out1 = rearrange(out1, 'b h n d -> b n (h d)')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch==2.6.0
 numpy==1.26.0
 torchdiffeq==0.2.5
 transformers==4.55.3
-bpy
+bpy==4.5.0
 git+https://github.com/facebookresearch/pytorch3d.git
 einops
 imageio[ffmpeg]

--- a/test_drive.py
+++ b/test_drive.py
@@ -37,7 +37,7 @@ def main(opt):
     torch.cuda.manual_seed_all(seed)
     
     # Video save dir
-    video_save_dir = os.path.join(opt.video_save_dir, opt.rf_exp)
+    video_save_dir = os.path.abspath(os.path.join(opt.video_save_dir, opt.rf_exp))
     if not os.path.exists(video_save_dir):
         os.makedirs(video_save_dir)
     
@@ -145,7 +145,7 @@ def main(opt):
         # assign trajs for each parts
         trajs = [outputs[0][:, idx].cpu() for idx in all_indices]
         # render video
-        drive_mesh_with_trajs_frames(mesh_objects, trajs, "{}/{}".format(video_save_dir, filepath.split("/")[-1].split(".")[0]), azi=opt.azi, ele=opt.ele, export_format=opt.export_format)
+        drive_mesh_with_trajs_frames(mesh_objects, trajs, os.path.join(video_save_dir, os.path.splitext(os.path.basename(filepath))[0]), azi=opt.azi, ele=opt.ele, export_format=opt.export_format)
     
 if __name__ == '__main__':
     import argparse

--- a/utils/render.py
+++ b/utils/render.py
@@ -650,7 +650,7 @@ def drive_mesh_with_trajs_frames(mesh_objects, trajs, output_dir, azi=0.0, ele=0
                 scene.render.filepath = os.path.join(frames_dir, f'frame_{frame:04d}.png')
                 bpy.ops.render.render(write_still=True)
                 print(f"Rendered {view_name} frame {frame}/{num_frames-1}")
-        filename = output_dir.split('/')[-1]
+        filename = os.path.basename(output_dir)
         print("Converting frames to videos...")
         frames = []
         for view_name, frames_dir in frames_dirs.items():
@@ -732,7 +732,7 @@ def drive_mesh_with_trajs_frames_five_views(mesh_objects, trajs, output_dir):
             bpy.ops.render.render(write_still=True)
             print(f"Rendered circle view frame {i}/{64}, angle {i}/64")
             bpy.data.objects.remove(circle_camera, do_unlink=True)
-        filename = output_dir.split('/')[-1]
+        filename = os.path.basename(output_dir)
         print("Converting frames to videos...")
         frames_circle = []
         frames_4views = []


### PR DESCRIPTION
- Fix path handling: use os.path.basename/splitext/abspath instead of string splits on forward slashes
- Pin bpy==4.5.0 for Blender API compatibility
- Enable math kernel fallback for scaled_dot_product_attention due to mismatched Q/K/V dimensions in SyncAttention